### PR TITLE
Add status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
+[![check-release](https://github.com/MHenderson/wallis/actions/workflows/check-release.yml/badge.svg)](https://github.com/MHenderson/wallis/actions/workflows/check-release.yml/badge.svg)
+[![wallis status badge](https://mhenderson.r-universe.dev/badges/wallis)](https://mhenderson.r-universe.dev/wallis)
+
 # wallis
+
 Room squares in R.


### PR DESCRIPTION
Both check-release workflow and r-universe status (even though wallis hasn't been added to r-universe yet).